### PR TITLE
feat: improve proto arrangement

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "hammer",
     "description": "Hammer for Visual Studio Code",
     "publisher": "zhileichen",
-    "version": "1.9.6",
+    "version": "1.9.7",
     "license": "MIT",
     "engines": {
         "vscode": "^1.35.0"

--- a/src/config/configModel.ts
+++ b/src/config/configModel.ts
@@ -3,6 +3,7 @@ import { FileModel } from './fileModel';
 export interface ConfigModel {
     configPath: string;
     organization?: string;
+    commonProtoPath?: string;
     projectId: number;
     directoryId: number;
     apiKey: string;

--- a/src/config/configProvider.ts
+++ b/src/config/configProvider.ts
@@ -57,6 +57,9 @@ export class ConfigProvider {
         if (!apiKey) {
             throw new Error(`Missing "api_token" property in ${this.workspace.name}`);
         }
+
+        const commonProtoPath: string | undefined = this.getOrEnv(config, 'common_proto_path', 'common_proto_path_env');
+        
         const basePath = this.getOrEnv(config, 'base_path', 'base_path_env');
         if (!!basePath) {
             const fullPath = path.join(this.workspace.uri.fsPath, basePath);
@@ -105,6 +108,7 @@ export class ConfigProvider {
             projectId: parseInt(projectId || ''),
             directoryId: parseInt(directoryId|| ''),
             apiKey: apiKey || '',
+            commonProtoPath: commonProtoPath,
             branch: config.branch,
             basePath,
             files: config.files.map(f => {
@@ -170,6 +174,7 @@ export class ConfigProvider {
 interface PrivateConfigModel {
     project_id: string;
     project_id_env: string;
+    common_proto_path?: string;
     base_url?: string;
     base_url_env?: string;
     api_token: string;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,11 +41,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // vscode.commands.registerCommand('translationProgress.refresh', () => progressProvider.refresh());
     vscode.commands.registerCommand('generator.mobx', args => genMobxCommand(args));
-    vscode.commands.registerCommand('generator.proto', args => genProtoCommand(args));
+    vscode.commands.registerCommand('generator.proto', args => genProtoCommand(args, configHolder));
     vscode.commands.registerCommand('generator.proto.update', args => {
         const uri = args as vscode.Uri;
         const newUri = vscode.Uri.file(uri.fsPath.replace('.twirp.dart', '.proto'));
-        genProtoCommand(newUri)
+        genProtoCommand(newUri, configHolder)
     });
 
     vscode.commands.registerCommand('hammer.enable_null_safety', args => enableNullSafety(args));

--- a/src/plugin/generator/protoGenerator.ts
+++ b/src/plugin/generator/protoGenerator.ts
@@ -35,11 +35,11 @@ const protocAction = async (binPath: string, fileName: string, args?: ReadonlyAr
         if (rootPath == undefined) {
             return "Unable to find root folder for project in both git or workspace";
         }
-        const commonProtoPath = "proto_def/lib/common"
+        const commonProtoPath = "banban_base/proto_def/lib/common"
         const commonImportPath = path.join(rootPath, commonProtoPath)
-        const outputPath = path.join(rootPath, 'proto_def/lib')
+        const outputPath = path.join(rootPath, 'banban_base/proto_def/lib')
         
-        var protocPluginPath = path.join(rootPath, 'tools', 'bin', 'proto2dart');
+        var protocPluginPath = path.join(rootPath, 'tools', 'bin', 'ptProtocPlugin');
         if (!cwd) {
             cwd = currentDir;
         }

--- a/src/plugin/generator/protoGenerator.ts
+++ b/src/plugin/generator/protoGenerator.ts
@@ -39,7 +39,7 @@ const protocAction = async (binPath: string, fileName: string, args?: ReadonlyAr
         const commonImportPath = path.join(rootPath, commonProtoPath)
         const outputPath = path.join(rootPath, 'proto_def/lib')
         
-        var protocPluginPath = path.join(rootPath, 'tools', 'proto2dart');
+        var protocPluginPath = path.join(rootPath, 'tools', 'bin', 'proto2dart');
         if (!cwd) {
             cwd = currentDir;
         }

--- a/src/plugin/generator/protoGenerator.ts
+++ b/src/plugin/generator/protoGenerator.ts
@@ -10,9 +10,11 @@ import { validEditor } from '../../util/editorvalidator';
 import { runProcess, safeSpawn } from '../../util/process';
 import { GitExtension } from '../../typings/git';
 import {readFileSync} from 'fs'
+import { CrowdinConfigHolder } from '../crowdinConfigHolder';
+import { ConfigModel } from '../../config/configModel';
 
 
-const protocAction = async (binPath: string, fileName: string, args?: ReadonlyArray<string>, cwd?: string | undefined): Promise<string> => {
+const protocAction = async (binPath: string, fileName: string,  config: CrowdinConfigHolder, args?: ReadonlyArray<string>, cwd?: string | undefined,): Promise<string> => {
     if (!args) {
         args = [];
     }
@@ -35,7 +37,13 @@ const protocAction = async (binPath: string, fileName: string, args?: ReadonlyAr
         if (rootPath == undefined) {
             return "Unable to find root folder for project in both git or workspace";
         }
-        const commonProtoPath = "banban_base/proto_def/lib/common"
+        var cfg: ConfigModel | undefined = undefined;
+                
+        for (let elem of config.configurations.entries()) {
+            cfg = elem[0];
+            
+        }
+        const commonProtoPath = cfg?.commonProtoPath ?? "banban_base/proto_def/lib/common"
         const commonImportPath = path.join(rootPath, commonProtoPath)
         const outputPath = path.join(rootPath, 'banban_base/proto_def/lib')
         
@@ -95,7 +103,7 @@ const getProtcBin = (
 const installProtobuf = (
 ): Promise<string> => execute('brew', ['install', 'protobuf'], {});
 
-export const genProtoCommand = (args: any) => {
+export const genProtoCommand = (args: any, config: CrowdinConfigHolder) => {
     return CommonUtil.withProgress(
         async () => {
             try {
@@ -122,7 +130,7 @@ export const genProtoCommand = (args: any) => {
                     return;
                 }
 
-                var result = await protocAction(protocBin, currentFsPath)
+                var result = await protocAction(protocBin, currentFsPath, config)
                 if (result != '') {
                     vscode.window.showInformationMessage(`failed: ${result}`);
                     return;

--- a/src/plugin/generator/protoGenerator.ts
+++ b/src/plugin/generator/protoGenerator.ts
@@ -39,7 +39,7 @@ const protocAction = async (binPath: string, fileName: string, args?: ReadonlyAr
         const commonImportPath = path.join(rootPath, commonProtoPath)
         const outputPath = path.join(rootPath, 'proto_def/lib')
         
-        var protocPluginPath = path.join(rootPath, 'tools', 'protoc_plugin.exe');
+        var protocPluginPath = path.join(rootPath, 'tools', 'proto2dart');
         if (!cwd) {
             cwd = currentDir;
         }


### PR DESCRIPTION
1. Generates proto based on git root.
2. Will generate `.pb` files into `proto_def/lib/pb`
3. Will generate `.api` files into `proto_def/lib/api`
4. Will now generate [proper well known types](https://protobuf.dev/reference/protobuf/google.protobuf/) in dart by importing related google protos